### PR TITLE
add setuptools_scm as a required dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ opts = dict(
     use_scm_version=True,
     packages=PACKAGES,
     include_package_data=True,
-    install_requires= ['sqlalchemy', 'pandas', 'numpy']
+    install_requires= ['sqlalchemy', 'pandas', 'numpy', "setuptools_scm"]
 )
 
 


### PR DESCRIPTION
The package won't currently work with just a `pip install .` because there's a dependency missing.