### PR TITLE
fix bug in city and geoid

### DIFF
--- a/sss/city.py
+++ b/sss/city.py
@@ -70,14 +70,76 @@ def add_city(path, year):
         if the state cannot be extracted from SSS_city
     """
     df = pd.read_excel(path)
-    df['state'] = df['SSS_City'].str.split(',').str[1]
-    df['state'] = df['state'].str.replace('*','')
+    us_state_to_abbrev = {
+    "Alabama": "AL",
+    "Alaska": "AK",
+    "Arizona": "AZ",
+    "Arkansas": "AR",
+    "California": "CA",
+    "Colorado": "CO",
+    "Connecticut": "CT",
+    "Delaware": "DE",
+    "Florida": "FL",
+    "Georgia": "GA",
+    "Hawaii": "HI",
+    "Idaho": "ID",
+    "Illinois": "IL",
+    "Indiana": "IN",
+    "Iowa": "IA",
+    "Kansas": "KS",
+    "Kentucky": "KY",
+    "Louisiana": "LA",
+    "Maine": "ME",
+    "Maryland": "MD",
+    "Massachusetts": "MA",
+    "Michigan": "MI",
+    "Minnesota": "MN",
+    "Mississippi": "MS",
+    "Missouri": "MO",
+    "Montana": "MT",
+    "Nebraska": "NE",
+    "Nevada": "NV",
+    "New Hampshire": "NH",
+    "New Jersey": "NJ",
+    "New Mexico": "NM",
+    "New York": "NY",
+    "North Carolina": "NC",
+    "North Dakota": "ND",
+    "Ohio": "OH",
+    "Oklahoma": "OK",
+    "Oregon": "OR",
+    "Pennsylvania": "PA",
+    "Rhode Island": "RI",
+    "South Carolina": "SC",
+    "South Dakota": "SD",
+    "Tennessee": "TN",
+    "Texas": "TX",
+    "Utah": "UT",
+    "Vermont": "VT",
+    "Virginia": "VA",
+    "Washington": "WA",
+    "West Virginia": "WV",
+    "Wisconsin": "WI",
+    "Wyoming": "WY",
+    "District of Columbia": "DC",
+    "American Samoa": "AS",
+    "Guam": "GU",
+    "Northern Mariana Islands": "MP",
+    "Puerto Rico": "PR",
+    "United States Minor Outlying Islands": "UM",
+    "U.S. Virgin Islands": "VI"
+    }
+    df['state'] = df['State'].map(us_state_to_abbrev)
+    #df['state'] = df['state'].str.replace('*','')
     if df.state.isna().sum()>0:
-        raise ValueError('could not find state in SSS_City value %s' % (df[df.state.isna()]['SSS_City']))
+        raise ValueError('could not find state in State value %s' % (df[df.state.isna()]['State']))
     df['PublicTransit'] = df['PublicTransit'].astype('bool')
     df = df[['state','SSS_Place','SSS_City', 'Census_Name','POPESTIMATE2021' , 'PublicTransit']]
     df.columns = ['state','place','sss_city', 'census_name','population' , 'public_transit']
     df['year'] = year
+    # drop the duplicates if the city infor is all the same
+    df = df.drop_duplicates()
+    df.reset_index(inplace=True, drop=True)
     return df
 
 

--- a/sss/puma.py
+++ b/sss/puma.py
@@ -172,7 +172,7 @@ def puma_crosswalk(path, year, nyc_wa_path = None):
         # left join county and puma by puma code
         crosswalk = county.merge(puma, how='left')
         # only keep columns of interests
-        crosswalk = crosswalk[['summary_level', 'state_fips', 'state','puma_code','county_fips', 'county', 'puma_area','population']]
+        crosswalk = crosswalk[['summary_level', 'state_fips', 'state','puma_code','county_fips', 'county', 'puma_area','population','year']]
         #creat place(sssplace)
         crosswalk['place'] = crosswalk['county']
     # attach population of each puma to the crosswalk file


### PR DESCRIPTION
City: city, drop duplicates and state to short name;
GeoID: if place and state name is same, add county to the end;
Puma: puma miss 'year' before.