### PR TITLE
Fix the way the version is derived

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,5 @@ requires = [
     "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ opts = dict(
     license='CC0 1.0',
     #classifiers=CLASSIFIERS,
     author='Cheng Ren, Aziza Mirsaidova, Priyana Patel, Hector Sosa, Bryna Hazelton',
-    use_scm_version=True,
     package_dir={"sss": "sss"},
     packages=find_namespace_packages(),
     include_package_data=True,

--- a/sss/__init__.py
+++ b/sss/__init__.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from pkg_resources import DistributionNotFound, get_distribution
 from setuptools_scm import get_version
 
 from .city import City
@@ -7,5 +10,16 @@ from .puma import PUMA
 from .report import Report
 from .preprocess import std_col_names
 
-__version__ = get_version()
+try:  # pragma: nocover
+    # get accurate version for developer installs
+    version_str = get_version(Path(__file__).parent.parent)
 
+    __version__ = version_str
+
+except (LookupError, ImportError):
+    try:
+        # Set the version automatically from the package details.
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:  # pragma: nocover
+        # package is not installed
+        pass


### PR DESCRIPTION
This fixes the way the package version is derived using setuptools_scm to work for editable and non-editable installs anywhere on the computer.

I also updated to the suggested usage in pyproject.toml rather than setup.py