### PR TITLE
add script for geoid and report

### DIFF
--- a/scripts/add_one_entry_reportdb.py
+++ b/scripts/add_one_entry_reportdb.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Script for creating the tables
+"""
+
+import argparse
+from sss.report import add_one_entry_reportdb
+from sss.base import default_db_file
+from datetime import datetime, date
+
+# creating parser object 
+parser = argparse.ArgumentParser(description = "Creating the report database")
+
+# defining arguements for the parser object
+parser.add_argument("year", type = int,
+                    help = "Enter year of the record")
+
+parser.add_argument("state", type = str,
+                    help = "Enter state name")
+
+parser.add_argument("analysis_type", type = str,
+                    help = "Enter analysis type")
+
+parser.add_argument("cpi_month", type = str,
+                    help = "Enter month e.g. May")
+
+parser.add_argument("cpi_year", type = int,
+                    help = "Enter year of CPI report")
+
+parser.add_argument("update_date", type = date,
+                    help = "update date, the format is date(2021,6,22)")
+
+parser.add_argument("update_person", type = str,
+                    help = "who update the report")
+
+parser.add_argument("-d","--db_file", type = str,
+                    help = "Enter the database file that the data should be put in",
+                    default=default_db_file)
+
+args = parser.parse_args()
+
+# call the function with arguments
+add_one_entry_reportdb( args.year, 
+                        args.state,
+                        args.analysis_type,
+                        args.cpi_month,
+                        args.cpi_year,
+                        args.update_date,
+                        args.update_person,
+                        db_file=args.db_file)

--- a/scripts/data_to_geoid.py
+++ b/scripts/data_to_geoid.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Script for creating the tables
+"""
+
+import argparse
+from sss.geoid import geoid_to_db
+from sss.base import default_db_file
+
+# creating parser object 
+parser = argparse.ArgumentParser(description = "Creating the Geo indentifier database")
+
+# defining arguements for the parser object
+parser.add_argument("county_table", type = str,
+                    help = "Enter path name of the county table including FIPS code")
+
+parser.add_argument("cpi_table", type = str,
+                    help = "Enter path the cpi region table")
+
+parser.add_argument("-d","--db_file", type = str,
+                    help = "Enter the database file that the data should be put in",
+                    default=default_db_file)
+
+args = parser.parse_args()
+
+# call the function with arguments
+geoid_to_db(args.county_table, args.cpi_table, db_file=args.db_file)

--- a/scripts/data_to_report.py
+++ b/scripts/data_to_report.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Script for creating the tables
+"""
+
+import argparse
+from sss.report import report_to_db
+from sss.base import default_db_file
+
+# creating parser object 
+parser = argparse.ArgumentParser(description = "Creating the report database")
+
+# defining arguements for the parser object
+parser.add_argument("path", type = str,
+                    help = "Enter path name of the report excel file")
+
+parser.add_argument("-d","--db_file", type = str,
+                    help = "Enter the database file that the data should be put in",
+                    default=default_db_file)
+
+args = parser.parse_args()
+
+# call the function with arguments
+report_to_db(args.path, db_file=args.db_file)

--- a/sss/geoid.py
+++ b/sss/geoid.py
@@ -73,27 +73,27 @@ def geo_identifier_creator(county_table, cpi_table):
     xl = pd.ExcelFile(county_table)
     # n_sheets = len(xl.sheet_names)
     df_l = pd.read_excel(county_table, sheet_name = 0, dtype=str)
-    print(df_l.head())
-    print("Read the first sheet of LEFT table"+' '+ xl.sheet_names[0]+'. \
+    print("Read the first sheet of COUNTY table"+' '+ xl.sheet_names[0]+'. \
         Please adjust the sheet order if your tagret table is not the first one')
-    df_l['fips_state'] = df_l['fips2010'].str[:2]
-    df_l['county_state'] = df_l['fips2010'].str[2:5]
+    df_l['state_fips'] = df_l['fips2010'].str[:2]
+    df_l['county_fips'] = df_l['fips2010'].str[2:5]
     df_l['place_fips'] = df_l['fips2010'].str[5:]
     
 
     xl_r = pd.ExcelFile(cpi_table)
     # n_sheets_r = len(xl_r.sheet_names)
     df_r = pd.read_excel(cpi_table, sheet_name = 0)
-    print("Read the first sheet of RIGHT table"+' '+ xl_r.sheet_names[0]+'.\
+    print("Read the first sheet of CPI table"+' '+ xl_r.sheet_names[0]+'.\
          Please adjust the sheet order if your tagret table is not the first one')
 
     try:
         df_combine = df_l.merge(df_r,left_on = 'state_alpha', right_on = 'USPS Abbreviation', how='left')
-        df_combine = df_combine.rename(columns={"state_alpha": "state", "CPI Region": "cpi_region","CPI SSS_Place":"place"})
+        df_combine = df_combine.rename(columns={"state_alpha": "state", "CPI Region": "cpi_region","SSS_Place":"place"})
         if df_combine.shape[0] != df_l.shape[0]:
             print('Merge sucessfully but new rows were created due to duplications in right(CPI) table')
     except:
         raise ValueError('Cannot merge, please check the two columns are named as "state_alpha" and "USPS Abbreviation"')
+
     if df_combine.duplicated(['state','place']).sum()>0:
         places = df_combine.loc[df_combine.duplicated(['state','place'],keep=False),'place'].values
         counties = df_combine.loc[df_combine.duplicated(['state','place'],keep=False),'countyname'].values
@@ -112,7 +112,7 @@ def geoid_to_db(county_table, cpi_table, db_file=default_db_file):
     county_file: string
             The path of the county table including FIPS code
     cpi_file : string
-            The path of the cpi_table including capi region
+            The path of the cpi_table including cpi region
     db_file : str
             database file name, ends with '.sqlite'.
 


### PR DESCRIPTION
I added script for geoid and report
One known bug in add_one_entry_reportdb.py.
I am not sure of the correct date format in the terminal. 
```
parser.add_argument("update_date", type = date,
                    help = "update date, the format is date(2021,6,22)")
```

In Python, the following code works 
`add_one_entry_reportdb(2020,'CA','Full','December',2020,date(2021,6,22),'Ama')`
