### PR TITLE
Update pandas version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ opts = dict(
     package_dir={"sss": "sss"},
     packages=find_namespace_packages(),
     include_package_data=True,
-    install_requires= ["pandas", "numpy", "setuptools_scm", "sqlalchemy"],
+    install_requires= ["pandas>=1.5", "numpy", "setuptools_scm", "sqlalchemy"],
     extras_require={
         "doc": ["sphinx", "pypandoc"],
         "dev": ["coverage", "sphinx", "pypandoc", "pytest", "pytest-cov"],


### PR DESCRIPTION
This was already updated in the readme and the conda yamls but I forgot to update it in the most important place: setup.py.

We should really fix the code to not require filtering the `SettingWithCopyWarning` (now tracked in #39), but for now we have it and we need to require the right version of pandas.