### PR TITLE
Fix the logic for updating the infant column for family types with "c"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Minimamba
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -48,8 +48,11 @@ jobs:
           fi
 
       - name: Install
+        # calling git right before the install seems to prevent a time-out within setuptools_scm on MacOS
         run: |
-          pip install --no-deps .
+          git describe --tags --always
+          git version
+          SETUPTOOLS_SCM_DEBUG=1 pip install --no-deps .
 
       - name: Upgrade Database Schema
         run: |
@@ -79,12 +82,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Minimamba
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/sss/sss_table.py
+++ b/sss/sss_table.py
@@ -392,12 +392,14 @@ def prepare_for_database(df):
     # Create a 'weighted_child_count' column from a*c* values
     #   this will take the infant count and move to this column
     df["weighted_child_count"] = df["infant"]
+    # first set the weighted_child_count to NaN for family types without "c"s
     df.loc[
         df.loc[:, "family_type"].isin([i for i in df["family_type"] if "c" not in i]),
         "weighted_child_count",
     ] = np.nan
+    # then set the infant to 0 for family types *with* "c"s
     df.loc[
-        df.loc[:, "family_type"].isin([i for i in df["family_type"] if "c" not in i]),
+        df.loc[:, "family_type"].isin([i for i in df["family_type"] if "c" in i]),
         "infant",
     ] = 0
 
@@ -432,9 +434,9 @@ def data_folder_to_database(data_path, testing=False):
     db = AutomappedDB(testing=testing)
     session = db.sessionmaker()
 
-    for i in data_files:
+    for fi in data_files:
         # read file and conduct pre-processing
-        df, file = read_file(i)
+        df, file = read_file(fi)
 
         # store dataframes created
         df, arpa, health_care, miscellaneous = check_extra_columns(df)


### PR DESCRIPTION
This fixes a bug that was causing the infant column to be set to zero for family types with infant counts and not to be set to zero for family types with "c" counts, which was backwards of what was intended.

The existing `update_columns` function in `sss_table.py` can be used to apply this fixed logic and only update the infant column.