### PR TITLE
Fix duplicate row handling

### DIFF
--- a/sss/puma.py
+++ b/sss/puma.py
@@ -11,10 +11,6 @@ from sqlalchemy import (
     Float,
 )
 
-import warnings
-from pandas.errors import SettingWithCopyWarning
-
-warnings.simplefilter(action="ignore", category=SettingWithCopyWarning)
 
 puma_state_numbers_to_abbreviations = {
     "53": "WA",

--- a/sss/sss_table.py
+++ b/sss/sss_table.py
@@ -410,6 +410,10 @@ def prepare_for_database(df):
 
     # removing duplicate rows
     df = df.drop_duplicates()
+
+    # Check for rows with duplicate primary keys and error if any present.
+    # These will error when entered into the database anyway and the code doesn't
+    # know which one to keep, user should fix this in the data.
     primary_keys = ["analysis_type", "family_type", "state", "year", "place"]
     primary_key_duplicates = df[df.duplicated(subset=primary_keys)]
     if len(primary_key_duplicates) > 0:

--- a/sss/sss_table.py
+++ b/sss/sss_table.py
@@ -409,9 +409,15 @@ def prepare_for_database(df):
     ] = 0
 
     # removing duplicate rows
-    df = df.drop_duplicates(
-        subset=["analysis_type", "family_type", "state", "year", "place"]
-    )
+    df = df.drop_duplicates()
+    primary_keys = ["analysis_type", "family_type", "state", "year", "place"]
+    primary_key_duplicates = df[df.duplicated(subset=primary_keys)]
+    if len(primary_key_duplicates) > 0:
+        raise ValueError(
+            "Some rows have identical primary keys with different data:\n"
+            f"{primary_key_duplicates[primary_keys]}"
+        )
+
     df.reset_index(inplace=True, drop=True)
     return df
 

--- a/sss/tests/test_sss.py
+++ b/sss/tests/test_sss.py
@@ -144,7 +144,6 @@ def test_duplicate_rows():
     assert prep_df.equals(prep_dup_df)
 
     df_altered = df.copy()
-    print(df.columns)
     df_altered["food"] = df["food"] * 2
     dup_pk_df = pd.concat([df, df_altered], ignore_index=True)
     assert len(dup_pk_df) == 2 * len(df)


### PR DESCRIPTION
Closes #14 
Closes #39 

Currently code identifies and drops rows that have identical primary key columns (keeping one for each, probably the first one?). The problem with this approach is that if there are rows that have the same primary key columns but different values in other rows the code would silently just drop those extra rows without notifying the user.

I think that silently dropping completely identical rows is fine, but if the rows differ in any way the user should be informed.

This PR changes the logic so that rows that are completely identical will still be dropped, but rows that are not identical but have identical primary keys will cause errors (because we don't know which one to keep).

This PR also removes some old warning handling that seems to not be required any more.
