### PR TITLE
Fix handling for new column naming of tax credits

### DIFF
--- a/sss/preprocess.py
+++ b/sss/preprocess.py
@@ -56,6 +56,7 @@ def std_col_names(pd_dataframe):
         pd_dataframe.columns = [
             col.replace(key, replace_dict[key]) for col in pd_dataframe.columns
         ]
+    pd_dataframe.columns = [col.strip("_").lower() for col in pd_dataframe.columns]
     return pd_dataframe
 
 

--- a/sss/tests/test_sss.py
+++ b/sss/tests/test_sss.py
@@ -127,6 +127,16 @@ def test_data_folder_to_database(setup_and_teardown_package):
     for res in result_2009:
         assert res.emergency_savings is None
 
+    result_arpa = session.query(SSS).filter(SSS.analysis_type == "ARPA").all()
+    for col in [
+        "earned_income_tax_credit",
+        "child_care_tax_credit",
+        "child_tax_credit",
+    ]:
+        col_obj = getattr(SSS, col)
+        result_tax_credit = session.query(SSS).filter(col_obj.is_(None)).all()
+        assert len(result_tax_credit) == len(result_arpa)
+
     session.close()
 
 


### PR DESCRIPTION
The tax credit columns weren't being filled properly because the new column naming hadn't been fully handled by the last fix.